### PR TITLE
www.twitter.com -> x.com

### DIFF
--- a/lib/twitter.rb
+++ b/lib/twitter.rb
@@ -12,7 +12,7 @@ class Twitter < OembedTitleFetcher
   listen_to :channel
 
   def allowed_hosts
-    %w(www.twitter.com twitter.com)
+    %w(x.com twitter.com)
   end
 
   def listen(m)


### PR DESCRIPTION
Moi,

twitter muutti hostin x.comiksi. API on edelleen api.twitter.com.

nyt siellä lukee 

def allowed_hosts
    %w(x.com twitter.com)
  end